### PR TITLE
Implement assembly picking via VSCode's open dialog

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -23,7 +23,8 @@
     ],
     "activationEvents": [
         "onCommand:ilspy.decompileAssemblyInWorkspace",
-        "onCommand:ilspy.decompileAssemblyPromptForFilePath"
+        "onCommand:ilspy.decompileAssemblyPromptForFilePath",
+        "onCommand:ilspy.decompileAssemblyViaDialog"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -44,6 +45,11 @@
             {
                 "command": "ilspy.decompileAssemblyPromptForFilePath",
                 "title": "Decompile IL Assembly from a Given Path",
+                "category": "ILSpy"
+            },
+            {
+                "command": "ilspy.decompileAssemblyViaDialog",
+                "title": "Decompile IL Assembly (pick file)",
                 "category": "ILSpy"
             }
         ]


### PR DESCRIPTION
This closes #15 by adding a new command `ilspy.decompileAssemblyViaDialog` which opens a file picker dialog and takes the path supplied.