### PR TITLE
Use temp directory and random file names for opened documents

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to the "ilspy-vscode" extension will be documented in this f
 
 ## 0.7.11
 
-* Use temp directory and random file names for decompiled documents.
+* Use temp directory and files to show decompiled documents.
 
 ## 0.7.10
 

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to the "ilspy-vscode" extension will be documented in this file.
 
+## 0.7.11
+
+* Use temp directory and random file names for decompiled documents.
+
 ## 0.7.10
 
 * Update to ILSpy 5.0.2

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -28,7 +28,7 @@ Loaded assemblies can be closed by right-click on the assemly nodes to show the 
 
 First release of ILSpy .NET Decompiler extension for Visual Studio Code!
 
-See our [change log](CHANGELOG.md) for all of the updates.
+See our [change log](https://github.com/icsharpcode/ilspy-vscode/blob/master/vscode-extension/CHANGELOG.md) for all of the updates.
 
 ### Found a Bug?
 Please file any issues at https://github.com/icsharpcode/ilspy-vscode/issues
@@ -49,4 +49,4 @@ To **test** do the following: `npm test` or <kbd>F5</kbd> in VS Code with the "L
 
 ## License
 
-[MIT license](LICENSE.TXT).
+[MIT license](https://github.com/icsharpcode/ilspy-vscode/blob/master/vscode-extension/LICENSE.TXT).

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
     "name": "ilspy-vscode",
     "displayName": "ILSpy .NET Decompiler",
     "description": "Decompile MSIL assemblies - support for full framework, .NET Core and .NET Standard",
-    "version": "0.7.10",
+    "version": "0.7.11",
     "icon": "resources/ILSpy-vscode-marketplace-icon.png",
     "publisher": "icsharpcode",
     "preview": true,
@@ -71,6 +71,7 @@
     },
     "dependencies": {
         "semver": "*",
+        "temp-dir": "^2.0.0",
         "vscode-extension-telemetry": "0.1.1"
     },
     "devDependencies": {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7,11 +7,15 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as fs from 'fs';
+import * as path from 'path';
+import * as tempDir from 'temp-dir';
 import * as vscode from 'vscode';
 import * as util from './common';
 import { MsilDecompilerServer } from './msildecompiler/server';
 import { DecompiledTreeProvider, MemberNode, LangaugeNames } from './msildecompiler/decompiledTreeProvider';
 import { DecompiledCode } from './msildecompiler/protocol';
+
+const tempFileName = new Date().getTime().toString();
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -124,14 +128,16 @@ function showCode(code: DecompiledCode) {
 }
 
 function showCodeInEditor(code: string, language: string, viewColumn: vscode.ViewColumn) {
-    const untitledFileName = language === "csharp" ? "untitled:ilspy-decompilation.cs" : "untitled:ilspy-decompilation.il";
+    const untitledFileName = `untitled:${path.join(tempDir, tempFileName)}.${language === "csharp" ? "cs" : "il"}`;
     const uri = vscode.Uri.parse(untitledFileName);
     vscode.workspace.openTextDocument(uri).then(document => {
         vscode.window.showTextDocument(document, viewColumn, true).then(e => {
             replaceCode(e, code);
+        }, reason => {
+            console.log("[Error] ilspy-vscode encountered an error while trying to show code: " + reason);
         });
     }, errorReason => {
-        console.log("[Error] ilspy-vscode encountered an error while trying to show code: " + errorReason);
+        console.log("[Error] ilspy-vscode encountered an error while trying to open text document: " + errorReason);
     });
 }
 

--- a/vscode-extension/src/msildecompiler/server.ts
+++ b/vscode-extension/src/msildecompiler/server.ts
@@ -187,6 +187,7 @@ export class MsilDecompilerServer {
         }).then(() => {
             this._requestQueue.drain();
         }).catch(err => {
+            this._logger.appendLine(`Error starting ILSpy.Host server: ${err}`);
             this._fireEvent(Events.ServerError, err);
             return this.stop();
         });


### PR DESCRIPTION
Related to issue #46 where VS Code tries to save them to root
directory.

Also update README.md to have absolute links to CHANGELOG and
LICENSE.TXT to avoid broken links when viewing in VS Code, extension
marketplace, or GitHub. This resolves #36.