### PR TITLE
Update package name for `vsce`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The extension consists of two parts: The VSCode extension itself (written in Typ
 If first time
 
 ```
-npm i vsce -g
+npm i @vscode/vsce -g
 ```
 
 Compile and package all parts:

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -112,7 +112,7 @@ class Build : NukeBuild
         .Executes(() =>
         {
             NpmInstall(s => s
-                .SetPackages("vsce")
+                .SetPackages("@vscode/vsce")
                 .SetGlobal(true));
             EnsureExistingDirectory(ArtifactsDirectory);
             var vsixFileName = $"ilspy-vscode-{ProjectVersion.Version.ToString(3) }.vsix";


### PR DESCRIPTION
Both inside README.md to avoid

```
❯ npm i vsce -g
npm WARN deprecated vsce@2.15.0: vsce has been renamed to @vscode/vsce. Install using @vscode/vsce instead.
```

and inside the build script/code to avoid

```
╬═════════
║ Vsix
╬══

> /opt/homebrew/bin/npm install vsce --global
npm WARN deprecated vsce@2.15.0: vsce has been renamed to @vscode/vsce. Install using @vscode/vsce instead.
```