### PR TITLE
Do not slow down vscode startup to initialize the extension

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -21,7 +21,7 @@
 		"Other"
 	],
 	"activationEvents": [
-		"*"
+		"onStartupFinished"
 	],
 	"main": "./out/extension.js",
 	"contributes": {


### PR DESCRIPTION
This fix the build warning

```
WARNING  Using '*' activation is usually a bad idea as it impacts performance.
More info: https://code.visualstudio.com/api/references/activation-events#Start-up
```

by using `onStartupFinished` to be notified once VSCode startup has completed

Reference: https://code.visualstudio.com/api/references/activation-events#onStartupFinished