### PR TITLE
Allow using a 3rd party extension for IL syntax highlighting

### DIFF
--- a/vscode-extension/src/decompiler/languageInfos.ts
+++ b/vscode-extension/src/decompiler/languageInfos.ts
@@ -7,7 +7,7 @@ export interface LanguageInfo {
 
 export const languageInfos: { [key: string]: LanguageInfo } = {
   [LanguageName.CSharp]: { displayName: "C#", vsLanguageMode: "csharp" },
-  [LanguageName.IL]: { displayName: "IL", vsLanguageMode: "plaintext" },
+  [LanguageName.IL]: { displayName: "IL", vsLanguageMode: "il" },
 };
 
 export const languageFromDisplayName = (name?: string) =>


### PR DESCRIPTION
Just like the one for C# is re-used.

https://marketplace.visualstudio.com/items?itemName=soltys.vscode-il is such an extension