### PR TITLE
Add 'Reload Assembly' command

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -78,6 +78,11 @@
 				"category": "ILSpy"
 			},
 			{
+				"command": "ilspy.reloadAssembly",
+				"title": "Reload Assembly",
+				"category": "ILSpy"
+			},
+			{
 				"command": "ilspy.selectOutputLanguage",
 				"title": "Output language",
 				"category": "ILSpy"
@@ -97,6 +102,11 @@
 			"view/item/context": [
 				{
 					"command": "ilspy.unloadAssembly",
+					"when": "view == ilspyDecompiledMembers && viewItem == assemblyNode",
+					"group": "1_GeneralCommands@1"
+				},
+				{
+					"command": "ilspy.reloadAssembly",
 					"when": "view == ilspyDecompiledMembers && viewItem == assemblyNode",
 					"group": "1_GeneralCommands@1"
 				}
@@ -119,6 +129,10 @@
 				},
 				{
 					"command": "ilspy.unloadAssembly",
+					"when": "ilspy.backendAvailable"
+				},
+				{
+					"command": "ilspy.reloadAssembly",
 					"when": "ilspy.backendAvailable"
 				},
 				{

--- a/vscode-extension/src/commands/reloadAssembly.ts
+++ b/vscode-extension/src/commands/reloadAssembly.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+import { DecompiledTreeProvider } from "../decompiler/DecompiledTreeProvider";
+import { MemberNode } from "../decompiler/MemberNode";
+
+export function registerReloadAssembly(
+  decompiledTreeProvider: DecompiledTreeProvider
+) {
+  return vscode.commands.registerCommand(
+    "ilspy.reloadAssembly",
+    async (node: MemberNode) => {
+      if (!node) {
+        vscode.window.showInformationMessage(
+          'Please use context menu: right-click on the assembly node then select "Reload Assembly"'
+        );
+        return;
+      }
+      await decompiledTreeProvider.reloadAssembly(node.assembly);
+    }
+  );
+}

--- a/vscode-extension/src/decompiler/DecompiledTreeProvider.ts
+++ b/vscode-extension/src/decompiler/DecompiledTreeProvider.ts
@@ -65,6 +65,25 @@ export class DecompiledTreeProvider implements TreeDataProvider<MemberNode> {
     return response?.removed ?? false;
   }
 
+  public async reloadAssembly(assembly: string): Promise<boolean> {
+    const response = await this.backend.sendRemoveAssembly({
+      assemblyPath: assembly,
+    });
+    if (response?.removed) {
+      this.backend.assemblies.delete(assembly);
+
+      const response = await this.backend.sendAddAssembly({
+        assemblyPath: assembly,
+      });
+      if (response?.added && response?.assemblyData) {
+        this.backend.assemblies.set(assembly, response.assemblyData);
+        this.refresh();
+        return true;
+      }
+    }
+    return false;
+  }
+
   public getTreeItem(element: MemberNode): TreeItem {
     return {
       label: element.name,
@@ -191,7 +210,7 @@ export class DecompiledTreeProvider implements TreeDataProvider<MemberNode> {
   }
 
   public getParent?(element: MemberNode): ProviderResult<MemberNode> {
-    // Note: This allows relealing of assembly nodes in TreeView, which are placed in root. It won't work for other nodes.
+    // Note: This allows releasing of assembly nodes in TreeView, which are placed in root. It won't work for other nodes.
     return undefined;
   }
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -14,6 +14,7 @@ import ILSpyBackend from "./decompiler/ILSpyBackend";
 import { DecompiledTreeProvider } from "./decompiler/DecompiledTreeProvider";
 import { registerDecompileAssemblyInWorkspace } from "./commands/decompileAssemblyInWorkspace";
 import { registerDecompileAssemblyViaDialog } from "./commands/decompileAssemblyViaDialog";
+import { registerReloadAssembly } from "./commands/reloadAssembly";
 import { registerUnloadAssembly } from "./commands/unloadAssembly";
 import { acquireDotnetRuntime } from "./dotnet-acquire/acquire";
 import OutputWindowLogger from "./OutputWindowLogger";
@@ -116,6 +117,7 @@ export async function activate(context: ExtensionContext) {
   disposables.push(
     registerSelectOutputLanguage(decompilerTextDocumentContentProvider)
   );
+  disposables.push(registerReloadAssembly(decompileTreeProvider));
   disposables.push(registerUnloadAssembly(decompileTreeProvider));
 
   context.subscriptions.push(...disposables);


### PR DESCRIPTION
Simplistic* approach but a time saver when using the extension. Partial fix for https://github.com/icsharpcode/ilspy-vscode/issues/88

* Pretty much `removeAssembly` and `addAssembly` but with a single `refresh` call. It would be cleaner to have a single call to the backend (maybe later).