### PR TITLE
Allow opening more than one assembly using the open dialog

### DIFF
--- a/vscode-extension/src/commands/decompileAssemblyViaDialog.ts
+++ b/vscode-extension/src/commands/decompileAssemblyViaDialog.ts
@@ -15,27 +15,27 @@ export function registerDecompileAssemblyViaDialog(
   return vscode.commands.registerCommand(
     "ilspy.decompileAssemblyViaDialog",
     async () => {
-      const file = await promptForAssemblyFilePathViaDialog();
-      if (file) {
+      const files = await promptForAssemblyFilesPathViaDialog();
+      files.forEach((file) => {
         addAssemblyFromFilePath(
           file,
           decompiledTreeProvider,
           decompiledTreeView
         );
-      }
+      });
     }
   );
 }
 
-async function promptForAssemblyFilePathViaDialog(): Promise<
-  string | undefined
+async function promptForAssemblyFilesPathViaDialog(): Promise<
+  string[]
 > {
   const uris = await vscode.window.showOpenDialog(
     /* options*/ {
-      openLabel: "Select assembly",
+      openLabel: "Select assemblies",
       canSelectFiles: true,
       canSelectFolders: false,
-      canSelectMany: false,
+      canSelectMany: true,
       filters: {
         ".NET Assemblies": ["dll", "exe", "winmd", "netmodule"],
       },
@@ -43,13 +43,8 @@ async function promptForAssemblyFilePathViaDialog(): Promise<
   );
 
   if (uris === undefined) {
-    return undefined;
+    return [];
   }
 
-  let strings = uris.map((uri) => uri.fsPath);
-  if (strings.length > 0) {
-    return strings[0];
-  } else {
-    return undefined;
-  }
+  return uris.map((uri) => uri.fsPath);
 }


### PR DESCRIPTION
Helps quite a bit since we can't (yet) open the assembly dependencies and drag-n-drop is not an option.