### PR TITLE
Tweak loading assemblies from the workspace

### DIFF
--- a/vscode-extension/src/commands/decompileAssemblyInWorkspace.ts
+++ b/vscode-extension/src/commands/decompileAssemblyInWorkspace.ts
@@ -35,9 +35,13 @@ async function pickAssembly(): Promise<AssemblyQuickPickItem | undefined> {
   const quickPickItems = assemblyPathInfo.map((info) =>
     createAssemblyQuickPickItem(info)
   );
-  return await vscode.window.showQuickPick<AssemblyQuickPickItem>(
-    quickPickItems
-  );
+  if (quickPickItems.length === 0) {
+    vscode.window.showInformationMessage("No assembly found inside the workspace");
+  } else {
+    return await vscode.window.showQuickPick<AssemblyQuickPickItem>(
+      quickPickItems
+    );
+  }
 }
 
 function parseAssemblyPath(assemblies: string[]): AssemblyPathInfo[] {
@@ -58,7 +62,7 @@ function parseAssemblyPath(assemblies: string[]): AssemblyPathInfo[] {
 }
 
 async function findAssemblies(): Promise<string[]> {
-  if (!vscode.workspace.rootPath) {
+  if (!vscode.workspace.workspaceFolders) {
     return Promise.resolve([]);
   }
 
@@ -66,7 +70,15 @@ async function findAssemblies(): Promise<string[]> {
     /*include*/ "{**/*.dll,**/*.exe,**/*.winmd,**/*.netmodule}",
     /*exclude*/ "{**/node_modules/**,**/.git/**,**/bower_components/**}"
   );
-  return resources.map((uri) => uri.fsPath);
+  return resources.map((uri) => uri.fsPath).sort((s1, s2) => {
+    if (s1 > s2) {
+      return 1;
+    } else if (s1 < s2) {
+      return -1;
+    } else {
+      return 0;
+    }
+  });
 }
 
 function createAssemblyQuickPickItem(


### PR DESCRIPTION
* Sort list of assemblies so they are easier to find
* Show a message, instead of an empty list, if no assembly is found in the workspace
* Remove use of deprecated `rootPath`