### PR TITLE
Fix `npm outdated` where Current < Wanted

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -203,9 +203,9 @@
 			}
 		},
 		"node_modules/@types/chai": {
-			"version": "4.2.18",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.18.tgz",
-			"integrity": "sha512-rS27+EkB/RE1Iz3u0XtVL5q36MGDWbgYe7zWiodyKNUnthxY0rukK5V36eiUCtCisB7NN8zKYH6DO2M37qxFEQ==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+			"integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
 			"dev": true
 		},
 		"node_modules/@types/eslint": {
@@ -257,15 +257,15 @@
 			"dev": true
 		},
 		"node_modules/@types/mocha": {
-			"version": "8.2.2",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.2.tgz",
-			"integrity": "sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==",
+			"version": "8.2.3",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
+			"integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "12.20.13",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.13.tgz",
-			"integrity": "sha512-1x8W5OpxPq+T85OUsHRP6BqXeosKmeXRtjoF39STcdf/UWLqUsoehstZKOi0CunhVqHG17AyZgpj20eRVooK6A==",
+			"version": "12.20.55",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+			"integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
 			"dev": true
 		},
 		"node_modules/@types/semver": {
@@ -474,9 +474,9 @@
 			"dev": true
 		},
 		"node_modules/@vscode/test-electron": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.3.tgz",
-			"integrity": "sha512-ps/yJ/9ToUZtR1dHfWi1mDXtep1VoyyrmGKC3UnIbScToRQvbUjyy1VMqnMEW3EpMmC3g7+pyThIPtPyCLHyow==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.2.2.tgz",
+			"integrity": "sha512-s5d2VtMySvff0UgqkJ0BMCr1es+qREE194EAodGIefq518W53ifvv69e80l9e2MrYJEqUUKwukE/w3H9o15YEw==",
 			"dev": true,
 			"dependencies": {
 				"http-proxy-agent": "^4.0.1",
@@ -485,7 +485,7 @@
 				"unzipper": "^0.10.11"
 			},
 			"engines": {
-				"node": ">=8.9.3"
+				"node": ">=16"
 			}
 		},
 		"node_modules/@vscode/vsce": {
@@ -1178,14 +1178,15 @@
 			]
 		},
 		"node_modules/chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+			"integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
 			"dependencies": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
+				"deep-eql": "^4.1.2",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			},
@@ -1514,14 +1515,14 @@
 			}
 		},
 		"node_modules/deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+			"integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
 			"dependencies": {
 				"type-detect": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=0.12"
+				"node": ">=6"
 			}
 		},
 		"node_modules/deep-extend": {
@@ -2843,6 +2844,14 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/loupe": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+			"integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+			"dependencies": {
+				"get-func-name": "^2.0.0"
+			}
+		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -2971,10 +2980,13 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"dev": true
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/mkdirp": {
 			"version": "0.5.5",
@@ -4373,9 +4385,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-			"integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+			"version": "4.9.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+			"integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -4986,9 +4998,9 @@
 			"dev": true
 		},
 		"@types/chai": {
-			"version": "4.2.18",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.18.tgz",
-			"integrity": "sha512-rS27+EkB/RE1Iz3u0XtVL5q36MGDWbgYe7zWiodyKNUnthxY0rukK5V36eiUCtCisB7NN8zKYH6DO2M37qxFEQ==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+			"integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
 			"dev": true
 		},
 		"@types/eslint": {
@@ -5040,15 +5052,15 @@
 			"dev": true
 		},
 		"@types/mocha": {
-			"version": "8.2.2",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.2.tgz",
-			"integrity": "sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==",
+			"version": "8.2.3",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
+			"integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
 			"dev": true
 		},
 		"@types/node": {
-			"version": "12.20.13",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.13.tgz",
-			"integrity": "sha512-1x8W5OpxPq+T85OUsHRP6BqXeosKmeXRtjoF39STcdf/UWLqUsoehstZKOi0CunhVqHG17AyZgpj20eRVooK6A==",
+			"version": "12.20.55",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+			"integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
 			"dev": true
 		},
 		"@types/semver": {
@@ -5168,9 +5180,9 @@
 			"dev": true
 		},
 		"@vscode/test-electron": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.3.tgz",
-			"integrity": "sha512-ps/yJ/9ToUZtR1dHfWi1mDXtep1VoyyrmGKC3UnIbScToRQvbUjyy1VMqnMEW3EpMmC3g7+pyThIPtPyCLHyow==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.2.2.tgz",
+			"integrity": "sha512-s5d2VtMySvff0UgqkJ0BMCr1es+qREE194EAodGIefq518W53ifvv69e80l9e2MrYJEqUUKwukE/w3H9o15YEw==",
 			"dev": true,
 			"requires": {
 				"http-proxy-agent": "^4.0.1",
@@ -5699,14 +5711,15 @@
 			"dev": true
 		},
 		"chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+			"integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
+				"deep-eql": "^4.1.2",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			}
@@ -5949,9 +5962,9 @@
 			}
 		},
 		"deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+			"integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
 			"requires": {
 				"type-detect": "^4.0.0"
 			}
@@ -6938,6 +6951,14 @@
 				"is-unicode-supported": "^0.1.0"
 			}
 		},
+		"loupe": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+			"integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+			"requires": {
+				"get-func-name": "^2.0.0"
+			}
+		},
 		"lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -7032,9 +7053,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
 			"dev": true
 		},
 		"mkdirp": {
@@ -8049,9 +8070,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-			"integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+			"version": "4.9.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+			"integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
 			"dev": true
 		},
 		"uc.micro": {


### PR DESCRIPTION
On the terminal they are the _red_ entries.

Before

```
$ npm outdated

Package                 Current    Wanted    Latest  Location                            Depended by
@types/chai              4.2.18     4.3.4     4.3.4  node_modules/@types/chai            vscode-extension
@types/mocha              8.2.2     8.2.3    10.0.1  node_modules/@types/mocha           vscode-extension
@types/node            12.20.13  12.20.55  18.11.18  node_modules/@types/node            vscode-extension
@vscode/test-electron     2.1.3     2.2.2     2.2.2  node_modules/@vscode/test-electron  vscode-extension
ansi-regex                5.0.1     5.0.1     6.0.1  node_modules/ansi-regex             vscode-extension
chai                      4.3.4     4.3.7     4.3.7  node_modules/chai                   vscode-extension
minimist                  1.2.6     1.2.7     1.2.7  node_modules/minimist               vscode-extension
mocha                     9.2.2     9.2.2    10.2.0  node_modules/mocha                  vscode-extension
typescript                4.2.4     4.9.4     4.9.4  node_modules/typescript             vscode-extension
vscode-languageclient     7.0.0     7.0.0     8.0.2  node_modules/vscode-languageclient  vscode-extension
webpack                  5.65.0    5.65.0    5.75.0  node_modules/webpack                vscode-extension
```

After

```
$ npm outdated

Package                 Current    Wanted    Latest  Location                            Depended by
@types/mocha              8.2.3     8.2.3    10.0.1  node_modules/@types/mocha           vscode-extension
@types/node            12.20.55  12.20.55  18.11.18  node_modules/@types/node            vscode-extension
ansi-regex                5.0.1     5.0.1     6.0.1  node_modules/ansi-regex             vscode-extension
mocha                     9.2.2     9.2.2    10.2.0  node_modules/mocha                  vscode-extension
vscode-languageclient     7.0.0     7.0.0     8.0.2  node_modules/vscode-languageclient  vscode-extension
webpack                  5.65.0    5.65.0    5.75.0  node_modules/webpack                vscode-extension
```

The remaining (non-red) entries are for available (but not wanted) package updates.