### PR TITLE
Allow decompilation from the explorer tree view

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -79,6 +79,11 @@
 		],
 		"commands": [
 			{
+				"command": "ilspy.decompileSelectedAssembly",
+				"title": "Decompile selected assembly",
+				"category": "ILSpy"
+			},
+			{
 				"command": "ilspy.decompileAssemblyInWorkspace",
 				"title": "Add assembly from workspace",
 				"category": "ILSpy"
@@ -111,6 +116,13 @@
 			}
 		],
 		"menus": {
+			"explorer/context": [
+				{
+					"command": "ilspy.decompileSelectedAssembly",
+					"group": "navigation",
+					"when": "resourceExtname == .dll || resourceExtname == .exe || resourceExtname == .winmd || resourceExtname == .netmodule"
+				}
+			],
 			"view/title": [
 				{
 					"command": "ilspy.decompileAssemblyInWorkspace",

--- a/vscode-extension/src/commands/decompileSelectedAssembly.ts
+++ b/vscode-extension/src/commands/decompileSelectedAssembly.ts
@@ -1,0 +1,22 @@
+import * as vscode from "vscode";
+import { DecompiledTreeProvider } from "../decompiler/DecompiledTreeProvider";
+import { addAssemblyToTree } from "./utils";
+import { MemberNode } from "../decompiler/MemberNode";
+
+export function registerDecompileSelectedAssembly(
+  decompiledTreeProvider: DecompiledTreeProvider,
+  decompiledTreeView: vscode.TreeView<MemberNode>
+) {
+  return vscode.commands.registerCommand(
+    "ilspy.decompileSelectedAssembly",
+    async (file) => {
+      if (file) {
+        await addAssemblyToTree(
+          file.path,
+          decompiledTreeProvider,
+          decompiledTreeView
+        );
+      }
+    }
+  );
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -14,6 +14,7 @@ import ILSpyBackend from "./decompiler/ILSpyBackend";
 import { DecompiledTreeProvider } from "./decompiler/DecompiledTreeProvider";
 import { registerDecompileAssemblyInWorkspace } from "./commands/decompileAssemblyInWorkspace";
 import { registerDecompileAssemblyViaDialog } from "./commands/decompileAssemblyViaDialog";
+import { registerDecompileSelectedAssembly } from "./commands/decompileSelectedAssembly";
 import { registerReloadAssembly } from "./commands/reloadAssembly";
 import { registerUnloadAssembly } from "./commands/unloadAssembly";
 import { acquireDotnetRuntime } from "./dotnet-acquire/acquire";
@@ -107,6 +108,9 @@ export async function activate(context: ExtensionContext) {
   );
   disposables.push(
     registerDecompileAssemblyViaDialog(decompileTreeProvider, decompileTreeView)
+  );
+  disposables.push(
+    registerDecompileSelectedAssembly(decompileTreeProvider, decompileTreeView)
   );
 
   const decompilerTextDocumentContentProvider =


### PR DESCRIPTION
This is faster (less clicks) and feels more natural (easier to find) to decompile an assembly by clicking on a anssembly that is listed in the explorer tree view.