### PR TITLE
ILSpyX depends on ICS.Decompiler, no need to have both dependencies

### DIFF
--- a/backend/src/ILSpy.Backend/ILSpy.Backend.csproj
+++ b/backend/src/ILSpy.Backend/ILSpy.Backend.csproj
@@ -1,39 +1,37 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <Company>ic#code</Company>
-    <Title>ILSpy .NET Decompiler LSP Backend</Title>
-    <Product>ILSpy .NET Decompiler</Product>
-    <Copyright>Copyright 2017-2023 ICSharpCode, Microsoft Corporation</Copyright>
-    <Nullable>enable</Nullable>
-    <Version>0.15.0</Version>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net6.0</TargetFramework>
+		<Company>ic#code</Company>
+		<Title>ILSpy .NET Decompiler LSP Backend</Title>
+		<Product>ILSpy .NET Decompiler</Product>
+		<Copyright>Copyright 2017-2023 ICSharpCode, Microsoft Corporation</Copyright>
+		<Nullable>enable</Nullable>
+		<Version>0.15.0</Version>
+	</PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\..\vscode-extension\bin\ilspy-backend</OutputPath>
-    <WarningLevel>4</WarningLevel>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\..\vscode-extension\bin\ilspy-backend</OutputPath>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="ICSharpCode.Decompiler" Version="8.0.0.7345" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.7" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include="System.Linq" Version="4.3.0" />
-    <PackageReference Include="ICSharpCode.ILSpyX" Version="8.0.0.7345" />
-  </ItemGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<OutputPath>..\..\..\vscode-extension\bin\ilspy-backend</OutputPath>
+		<WarningLevel>4</WarningLevel>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<OutputPath>..\..\..\vscode-extension\bin\ilspy-backend</OutputPath>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="ICSharpCode.ILSpyX" Version="8.0.0.7345" />
+		<PackageReference Include="Mono.Cecil" Version="0.11.5" />
+		<PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.7" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+		<PackageReference Include="Serilog" Version="2.12.0" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
+		<PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Remove="ICSharpCode.ILSpyX" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="ICSharpCode.ILSpyX" />
+	</ItemGroup>
 </Project>
-  
+


### PR DESCRIPTION
also removed System.Linq. Note that ILSpyX references Mono.Cecil .14 vs .15 here in backend. Didn't touch.